### PR TITLE
feat: custom URLs in source & target, fix windows paths

### DIFF
--- a/integrations/sparkle/build.go
+++ b/integrations/sparkle/build.go
@@ -258,3 +258,8 @@ func write(ctx context.Context, c *Config, rss *RSS) error {
 
 	return w.Close()
 }
+
+//nolint:gochecknoinits // Don't use carriage return on windows.
+func init() {
+	xmlfmt.NL = "\n"
+}

--- a/internal/blob/source_test.go
+++ b/internal/blob/source_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSource(t *testing.T) {
-	s, err := blob.NewSource("mem://", "", "mem:/")
+	s, err := blob.NewSource("mem://", "", "mem://")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/emulator/container.go
+++ b/internal/emulator/container.go
@@ -3,7 +3,6 @@ package emulator
 import (
 	"context"
 	"log"
-	"net"
 	"strconv"
 	"testing"
 
@@ -62,17 +61,12 @@ func RunContainer(c Container) (*Service, error) {
 		}
 	}()
 
-	mappedPort, err := container.MappedPort(ctx, nat.Port(port))
+	host, err := container.PortEndpoint(ctx, nat.Port(port), "")
 	if err != nil {
 		return nil, err
 	}
 
-	hostIP, err := container.Host(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Service{Host: net.JoinHostPort(hostIP, mappedPort.Port()), container: container}, nil
+	return &Service{Host: host, container: container}, nil
 }
 
 func TestContainer(t *testing.T, c Container) string {

--- a/internal/test/source.go
+++ b/internal/test/source.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +30,16 @@ func Source(t *testing.T, s *source.Source, makeURL func(version, asset string) 
 	opt := []cmp.Option{
 		cmpopts.EquateApproxTime(10 * time.Second),
 		cmpopts.SortSlices(func(a, b *source.Asset) bool { return a.Name < b.Name }),
+
+		// Ignore asset URL query.
+		cmp.FilterPath(
+			func(p cmp.Path) bool { return strings.HasPrefix(p.String(), "Assets.URL") },
+			cmp.Comparer(func(a, b string) bool {
+				a, _, _ = strings.Cut(a, "?")
+				b, _, _ = strings.Cut(b, "?")
+				return a == b
+			}),
+		),
 	}
 
 	t.Run("ListReleases", func(t *testing.T) {

--- a/internal/testsource/testsource_test.go
+++ b/internal/testsource/testsource_test.go
@@ -1,7 +1,7 @@
 package testsource_test
 
 import (
-	"path/filepath"
+	"path"
 	"testing"
 
 	"github.com/abemedia/appcast/internal/test"
@@ -11,6 +11,6 @@ import (
 func TestFile(t *testing.T) {
 	s := testsource.New(test.SourceWant())
 	test.Source(t, s, func(version, asset string) string {
-		return "https://example.com/" + filepath.Join(version, asset)
+		return "https://example.com/" + path.Join(version, asset)
 	})
 }

--- a/pkg/pipe/pipe_test.go
+++ b/pkg/pipe/pipe_test.go
@@ -13,20 +13,20 @@ import (
 	"github.com/abemedia/appcast/pkg/crypto/dsa"
 	"github.com/abemedia/appcast/pkg/crypto/ed25519"
 	"github.com/abemedia/appcast/pkg/pipe"
-	fileSource "github.com/abemedia/appcast/source/file"
-	fileTarget "github.com/abemedia/appcast/target/file"
+	source "github.com/abemedia/appcast/source/file"
+	target "github.com/abemedia/appcast/target/file"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestPipe(t *testing.T) {
 	dir := t.TempDir()
 
-	src, err := fileSource.New(fileSource.Config{Path: dir})
+	src, err := source.New(source.Config{Path: dir})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tgt, err := fileTarget.New(fileTarget.Config{Path: dir})
+	tgt, err := target.New(target.Config{Path: dir})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/source/azureblob/azureblob.go
+++ b/source/azureblob/azureblob.go
@@ -9,8 +9,9 @@ import (
 type Config struct {
 	Bucket string
 	Folder string
+	URL    string
 }
 
 func New(c Config) (*source.Source, error) {
-	return blob.NewSource("azblob://"+c.Bucket, c.Folder, "")
+	return blob.NewSource("azblob://"+c.Bucket, c.Folder, c.URL)
 }

--- a/source/file/file.go
+++ b/source/file/file.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"net/url"
 	"path/filepath"
 
 	"github.com/abemedia/appcast/internal/blob"
@@ -10,6 +11,7 @@ import (
 
 type Config struct {
 	Path string
+	URL  string
 }
 
 func New(c Config) (*source.Source, error) {
@@ -17,6 +19,12 @@ func New(c Config) (*source.Source, error) {
 	if err != nil {
 		return nil, err
 	}
-	url := "file://" + path
-	return blob.NewSource(url, "", url)
+	url, err := url.JoinPath("file:///", filepath.ToSlash(path))
+	if err != nil {
+		return nil, err
+	}
+	if c.URL == "" {
+		c.URL = url
+	}
+	return blob.NewSource(url, "", c.URL)
 }

--- a/source/file/file_test.go
+++ b/source/file/file_test.go
@@ -1,6 +1,7 @@
 package file_test
 
 import (
+	"net/url"
 	"path/filepath"
 	"testing"
 
@@ -9,14 +10,31 @@ import (
 )
 
 func TestFile(t *testing.T) {
-	path := t.TempDir()
-
-	s, err := file.New(file.Config{Path: path})
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"FileURL", ""},
+		{"CustomURL", "http://dl.example.com"},
 	}
 
-	test.Source(t, s, func(version, asset string) string {
-		return "file://" + filepath.Join(path, version, asset)
-	})
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			path := t.TempDir()
+
+			s, err := file.New(file.Config{Path: path, URL: testCase.url})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			baseURL := testCase.url
+			if baseURL == "" {
+				baseURL, _ = url.JoinPath("file:///", filepath.ToSlash(path))
+			}
+
+			test.Source(t, s, func(version, asset string) string {
+				return baseURL + "/" + version + "/" + asset
+			})
+		})
+	}
 }

--- a/source/gcs/gcs.go
+++ b/source/gcs/gcs.go
@@ -9,8 +9,12 @@ import (
 type Config struct {
 	Bucket string
 	Folder string
+	URL    string
 }
 
 func New(c Config) (*source.Source, error) {
-	return blob.NewSource("gs://"+c.Bucket, c.Folder, "https://storage.googleapis.com/"+c.Bucket)
+	if c.URL == "" {
+		c.URL = "https://storage.googleapis.com/" + c.Bucket
+	}
+	return blob.NewSource("gs://"+c.Bucket, c.Folder, c.URL)
 }

--- a/source/s3/s3.go
+++ b/source/s3/s3.go
@@ -14,6 +14,7 @@ type Config struct {
 	Endpoint   string
 	Region     string
 	DisableSSL bool
+	URL        string
 }
 
 func New(c Config) (*source.Source, error) {
@@ -28,5 +29,5 @@ func New(c Config) (*source.Source, error) {
 		q.Add("endpoint", c.Endpoint)
 		q.Add("s3ForcePathStyle", "true")
 	}
-	return blob.NewSource("s3://"+c.Bucket+"?"+q.Encode(), c.Folder, "")
+	return blob.NewSource("s3://"+c.Bucket+"?"+q.Encode(), c.Folder, c.URL)
 }

--- a/target/github/github.go
+++ b/target/github/github.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/abemedia/appcast/target"
@@ -86,7 +85,7 @@ func (t *githubTarget) NewReader(ctx context.Context, filename string) (io.ReadC
 
 func (t *githubTarget) Sub(dir string) target.Target {
 	sub := *t
-	sub.path = filepath.Join(t.path, dir)
+	sub.path = path.Join(t.path, dir)
 	return &sub
 }
 


### PR DESCRIPTION
- Allow custom URLs to be passed to most sources & targets
- Use signed URLs for Azure Blob & AWS
- Fix paths in URLs when running on Windows
- Remove carriage returns from App Installer XML when generated on Windows
- Improve tests