### PR TITLE
fix(apt): deb encoding bugs

### DIFF
--- a/integrations/apt/deb/utils_test.go
+++ b/integrations/apt/deb/utils_test.go
@@ -23,6 +23,18 @@ func (s *marshaler) UnmarshalText(text []byte) error {
 	return nil
 }
 
+type errMarshaler struct {
+	E error
+}
+
+func (s errMarshaler) MarshalText() ([]byte, error) {
+	return nil, s.E
+}
+
+func (s *errMarshaler) UnmarshalText([]byte) error {
+	return s.E
+}
+
 type record struct {
 	String    string
 	Hex       [4]byte


### PR DESCRIPTION
- Fix multi-line stringer/marshaler encoding.
- Fix nil stringer panic.
- Fix unmarshal non-pointer type.
- Reduce multi-line sting encoder allocs. 
- Better error handling on invalid inputs.
- Fix hex data unmarshaling.
- Improve test coverage.