### PR TITLE
fix(pgp): invalid signature on fedora 39

### DIFF
--- a/integrations/apt/acceptance_test.go
+++ b/integrations/apt/acceptance_test.go
@@ -60,12 +60,12 @@ func TestAcceptance(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					c.Exec(t, "apt-get update -qq")
+					c.Exec(t, "apt-get update -q")
 
 					if i == 0 {
-						c.Exec(t, "apt-get install -qq -y --no-install-recommends appcast-test")
+						c.Exec(t, "apt-get install -yq --no-install-recommends appcast-test")
 					} else {
-						c.Exec(t, "apt-get upgrade -qq -y")
+						c.Exec(t, "apt-get upgrade -yq")
 					}
 
 					if v := c.Exec(t, "appcast-test"); v != test.version {

--- a/integrations/apt/release.go
+++ b/integrations/apt/release.go
@@ -180,7 +180,10 @@ func writeRelease(dir string, r Releases, key *pgp.PrivateKey) error {
 		if err = os.WriteFile(filepath.Join(dir, "Release.gpg"), sig, 0o600); err != nil {
 			return err
 		}
-		b = pgp.Join(b, sig)
+		b, err = pgp.SignText(key, b)
+		if err != nil {
+			return err
+		}
 	}
 
 	return os.WriteFile(filepath.Join(dir, "InRelease"), b, 0o600)

--- a/integrations/yum/acceptance_test.go
+++ b/integrations/yum/acceptance_test.go
@@ -32,7 +32,7 @@ func TestAcceptance(t *testing.T) {
 	}{
 		{"RHEL 9", "registry.access.redhat.com/ubi9/ubi:latest", "dnf"},
 		{"RHEL 8", "registry.access.redhat.com/ubi8/ubi:latest", "dnf"},
-		// {"Fedora 39", "fedora:39", "dnf"}, // TODO: Fix GPG error.
+		{"Fedora 39", "fedora:39", "dnf"},
 		{"Fedora 38", "fedora:38", "dnf"},
 		{"openSUSE Leap 15", "opensuse/leap:15", "zypper"},
 	}


### PR DESCRIPTION
Fixes the error `repomd.xml GPG signature verification error: Bad PGP signature` when installing on Fedora 39 with `repo_gpgcheck` enabled by signing messages as binary instead of cleartext.