### PR TITLE
build: fix pre-commit hook

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-golangci-lint run --new
+golangci-lint run --fast


### PR DESCRIPTION
The `--new` flag applies only to unstaged files if there are any.